### PR TITLE
Use self.observation_space instead of self._observation_space

### DIFF
--- a/gym_examples/wrappers/clip_reward.py
+++ b/gym_examples/wrappers/clip_reward.py
@@ -7,7 +7,7 @@ class ClipReward(gym.RewardWrapper):
         super().__init__(env)
         self.min_reward = min_reward
         self.max_reward = max_reward
-        self._reward_range = (min_reward, max_reward)
+        self.reward_range = (min_reward, max_reward)
 
     def reward(self, reward):
         return np.clip(reward, self.min_reward, self.max_reward)

--- a/gym_examples/wrappers/discrete_actions.py
+++ b/gym_examples/wrappers/discrete_actions.py
@@ -6,7 +6,7 @@ class DiscreteActions(gym.ActionWrapper):
     def __init__(self, env, disc_to_cont):
         super().__init__(env)
         self.disc_to_cont = disc_to_cont
-        self._action_space = Discrete(len(disc_to_cont))
+        self.action_space = Discrete(len(disc_to_cont))
 
     def action(self, act):
         return self.disc_to_cont[act]

--- a/gym_examples/wrappers/relative_position.py
+++ b/gym_examples/wrappers/relative_position.py
@@ -6,7 +6,7 @@ import numpy as np
 class RelativePosition(gym.ObservationWrapper):
     def __init__(self, env):
         super().__init__(env)
-        self._observation_space = Box(shape=(2,), low=-np.inf, high=np.inf)
+        self.observation_space = Box(shape=(2,), low=-np.inf, high=np.inf)
 
     def observation(self, obs):
         return obs["target"] - obs["agent"]


### PR DESCRIPTION
We were using `self._observation_space`, `self._reward_range` etc instead of `self.observation_space`, `self.reward_range` etc. That works, but we are using an implementation detail, which we probably shouldn't.